### PR TITLE
Fix endless loop when awaiting Lnurl

### DIFF
--- a/models/lnurl.py
+++ b/models/lnurl.py
@@ -60,7 +60,9 @@ class LnurlModel(db.Model):
 
     @classmethod
     def find_by_uuid(cls, uuid):
-        return cls.query.filter_by(uuid=uuid).first()
+        record =  cls.query.filter_by(uuid=uuid).first()
+        db.session.close()
+        return record
 
     def save_to_db(self):
         db.session.add(self)

--- a/resources/lnurl.py
+++ b/resources/lnurl.py
@@ -33,9 +33,9 @@ class LnurlCreate(Resource):
 
 class LnurlAwait(Resource):
     def get(self, uuid):
-        # db_entry = LnurlModel.find_by_uuid(uuid)
-        # if not db_entry:
-        #     return {"status": "ERROR", "reason": "Lnurl not found."}, 404
+        db_entry = LnurlModel.find_by_uuid(uuid)
+        if not db_entry:
+            return {"status": "ERROR", "reason": "Lnurl not found."}, 404
 
         invoice = ""
         while not invoice:


### PR DESCRIPTION
In resource `LnurlAwait` the check for an existing LNURL in the database causes the subsequent loop to run for ever since the `invoice` variable is never filled. It seems that the call `LnurlModel.find_by_uuid(uuid)` does not actually query the database anymore after the first call on line 36. So an updated value will not be detected. However, when closing the db session explicitly the subsequent calls get 'fresh' data.

I propose the following test script which simulates a LNURL capable wallet submitting an invoice after a delay of 5 seconds.

```python
import requests, time, json, qrcode, time, threading, logging

def findnth(haystack, needle, n):
    parts= haystack.split(needle, n+1)
    if len(parts)<=n+1:
        return -1
    return len(haystack)-len(parts[-1])-len(needle)

def wallet_action(uuid):
    sleep = 5
    logger.info(f'Starts in {sleep} seconds')
    time.sleep(sleep)

    request_lnurl = "http://lnurl.test:5000/v1/lnurl/" + uuid
    response_lnurl = requests.get(request_lnurl)
    lnurl_json = response_lnurl.json()

    request_withdraw =  lnurl_json['callback']
    k1 = lnurl_json['k1']
    pr = 'lnbc5u1p0fa0g0pp5z0xnnq63p7fx7vs3t4sx9sapk3lvpeppffy0pursn6fz5m99xr0qdqqcqzpgxqyz5vqsp59kyl2900ggel0e8gr2s3uv4ze5d96aqdm0q597npqn4mlkm0fwes9qy9qsq8s2d96sljuhnu9za7edskaxlmur2rxuzhg4ckyctq970nsplxev8ccdfs9jmw75t79vvxhqpsz3r83xf7qzc9fcss8jxwmkdgxt7kusp0j3dl5'
    data = {'k1': k1, 'pr': pr}
    logger.info(f'Submits k1: {k1}, pr: {pr}')
    response_withdraw = requests.get(request_withdraw, params=data)
    response_withdraw.json()

logging.basicConfig(level="INFO", format='%(threadName)-6s | %(message)s')
logger = logging.getLogger(__name__)

threading.current_thread().name = "main"
request_url = "http://lnurl.test:5000/v1/lnurl"
data = {"amount": 500}
response = requests.post(request_url, json=data)

logger.info("Received LNURL:" + response.json()["lnurl"])
callback = response.json()["callback"]
logger.info
logger.info("Received 'await-invoice' URL:" + callback)


uuid = callback[findnth(callback, '/', 4)+1 : findnth(callback, '/', 5)]
wallet_thread = threading.Thread(target=wallet_action, args=[uuid], name="wallet")
wallet_thread.start()

logger.info(f'Starts longpolling at {callback} \n')
response = requests.get(callback)
logger.info('Here is the invoice your wallet just submitted over "LNURLProxyAPI:"')
logger.info(response.json()['invoice'])

```